### PR TITLE
feat: set grafana API key header as config

### DIFF
--- a/application.yml.sample
+++ b/application.yml.sample
@@ -8,6 +8,9 @@ GRAFANA_GET_URL: "https://target-grafana-url"
 # GRAFANA_API_KEY is the admin api key required to create dashboards from playground code
 GRAFANA_API_KEY: "secret-api-key"
 
+# GRAFANA_API_KEY_HEADER_NAME is the header name used to sent grafana API key to create and delete dashboards
+GRAFANA_API_KEY_HEADER_NAME: "Authorization"
+
 # GRAFONNET_LIB_DIR is the location where grafonnet-lib is cloned
 # It can also have other plugins as a slice
 # See https://github.com/grafana/grafonnet-lib

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,8 @@ type Config struct {
 	GrafanaGetURL string
 	// GrafanaApiKey is the admin api key for grafana to create dashboards
 	GrafanaAPIKey string
+	// GrafanaAPIKeyHeaderName is the header name to sent grafanaAPIKey
+	GrafanaAPIKeyHeaderName string
 	// GrafonnetLibDirs is a slice of location of grafonnet lib that the app should
 	// have access to. It can be managed as the situation dictates during the build
 	// or package phase
@@ -48,6 +50,7 @@ func Load() *Config {
 	viper.SetDefault("AUTO_CLEANUP_INTERVAL", "30s")
 	viper.SetDefault("AUTO_CLEANUP_MIN_BACKOFF", "30s")
 	viper.SetDefault("AUTO_CLEANUP_MAX_BACKOFF", "5m")
+	viper.SetDefault("GRAFANA_API_KEY_HEADER_NAME", "Authorization")
 	viper.ReadInConfig()
 	viper.AutomaticEnv()
 
@@ -57,6 +60,7 @@ func Load() *Config {
 		GrafanaAPIKey:               mustHaveString("GRAFANA_API_KEY"),
 		GrafonnetLibDirs:            mustHaveStringSlice("GRAFONNET_LIB_DIRS"),
 		GrafonnetPlaygroundFolderID: viper.GetInt("GRAFONNET_PLAYGROUND_FOLDER_ID"),
+		GrafanaAPIKeyHeaderName:     viper.GetString("GRAFANA_API_KEY_HEADER_NAME"),
 		AutoCleanup:                 viper.GetBool("AUTO_CLEANUP"),
 		CleanupAfter:                viper.GetDuration("CLEANUP_AFTER"),
 		AutoCleanupInterval:         viper.GetDuration("AUTO_CLEANUP_INTERVAL"),

--- a/grafana/grafana.go
+++ b/grafana/grafana.go
@@ -59,7 +59,7 @@ func (g *grafana) CreateDashboard(cr *CreateRequest) (*CreateResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+g.cfg.GrafanaAPIKey)
+	req.Header.Set(g.cfg.GrafanaAPIKeyHeaderName, "Bearer "+g.cfg.GrafanaAPIKey)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 
@@ -90,7 +90,7 @@ func (g *grafana) DeleteDashboard(uid string) error {
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Authorization", "Bearer "+g.cfg.GrafanaAPIKey)
+	req.Header.Set(g.cfg.GrafanaAPIKeyHeaderName, "Bearer "+g.cfg.GrafanaAPIKey)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 


### PR DESCRIPTION
Update Grafana Authorization header to config as IAP sidecar also sets Authorization header which overwrites grafana API key header